### PR TITLE
feat: generate and serve pdf documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # ecqs-feature-stampa-protocolli
+
+Servizio REST scritto in **Kotlin** con **Spring Boot** per la generazione e il recupero di documenti PDF relativi a pratiche di prestito. I PDF vengono creati a partire da un template Word (`template.docx`) che viene popolato tramite *poi-tl* e convertito in PDF utilizzando **docx4j-export-fo** e **Apache FOP**.
+
+## Endpoints principali
+
+### `GET /stampa/{idPratica}/{tipologia}`
+
+Genera un nuovo PDF per la pratica indicata.
+
+- `idPratica`: stringa alfanumerica di 8 caratteri.
+- `tipologia`: una tra `allegato-b`, `pre-benestare`, `sinistri`.
+
+La risposta contiene il PDF generato con nome file `TIPOLOGIA_idPratica.pdf`.
+
+### `GET /stampa/{protocollo}`
+
+Recupera un PDF precedentemente generato tramite protocollo.
+
+- `protocollo`: stringa alfanumerica nel formato `xxx-xxx`.
+
+La risposta contiene il PDF associato.
+
+## Avvio e test
+
+```bash
+./gradlew bootRun   # avvia l'applicazione
+./gradlew test      # esegue la suite di test
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,9 +9,9 @@ group = "com.ecqs"
 version = "1.0.0"
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+        toolchain {
+                languageVersion = JavaLanguageVersion.of(17)
+        }
 }
 
 repositories {
@@ -22,7 +22,10 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("com.deepoove:poi-tl:1.12.2")
+        implementation("com.deepoove:poi-tl:1.12.2")
+        implementation("org.docx4j:docx4j-JAXB-ReferenceImpl:11.4.9")
+        implementation("org.docx4j:docx4j-export-fo:11.4.9")
+        implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/kotlin/com/ecqs/features/stampa/controller/StampaController.kt
+++ b/src/main/kotlin/com/ecqs/features/stampa/controller/StampaController.kt
@@ -11,12 +11,13 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
+import io.swagger.v3.oas.annotations.Operation
 
 @RestController
 @RequestMapping("/stampa")
-// TODO: Sviluppare la documentazione Swagger/OpenAPI per gli endpoint di stampa.
 class StampaController(private val stampaService: StampaService) {
 
+    @Operation(summary = "Genera un nuovo PDF per la pratica indicata")
     @GetMapping("/{idPratica}/{tipologia}")
     fun getDocument(
         @PathVariable idPratica: String,
@@ -24,10 +25,11 @@ class StampaController(private val stampaService: StampaService) {
     ): ResponseEntity<Resource> {
         val protocollo = generateNewProtocollo() // Genera un nuovo protocollo
         val resource = stampaService.getDocument(idPratica, tipologia, protocollo)
-        val filename = "${TipologiaDocumento.fromString(tipologia).displayName.replace(" ", "_")}_${idPratica}.docx"
+        val filename = "${TipologiaDocumento.fromString(tipologia).displayName.replace(" ", "_")}_${idPratica}.pdf"
         return buildResponse(resource, filename)
     }
 
+    @Operation(summary = "Recupera un PDF esistente tramite protocollo")
     @GetMapping("/{protocollo}")
     fun getDocumentWithProtocol(
         @PathVariable protocollo: String
@@ -51,7 +53,7 @@ class StampaController(private val stampaService: StampaService) {
         }
         return ResponseEntity.ok()
             .headers(headers)
-            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .contentType(MediaType.APPLICATION_PDF)
             .body(resource)
     }
 }

--- a/src/main/kotlin/com/ecqs/features/stampa/service/StampaService.kt
+++ b/src/main/kotlin/com/ecqs/features/stampa/service/StampaService.kt
@@ -12,28 +12,32 @@ import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.Resource
 import org.springframework.core.io.ResourceLoader
 import org.springframework.stereotype.Service
+import org.docx4j.Docx4J
+import org.docx4j.openpackaging.packages.WordprocessingMLPackage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.util.Base64
 
 @Service
 class StampaService(private val resourceLoader: ResourceLoader) {
 
-    private val MOCK_PRATICA_ID = "N06FOOGHY"
+    private val MOCK_PRATICA_ID = "N06FOOGH"
     private val MOCK_PROTOCOLLO = "123-asd"
     private val TEMPLATE_NAME = "template.docx"
-    private val MOCK_DB_DOCUMENT_BASE64 = "SGFsbG8sIFdlbHQh" // "Hallo, Welt!"
+    private val MOCK_DB_DOCUMENT_BASE64 = "JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9Db3VudCAxIC9LaWRzIFszIDAgUl0gPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA1OTUuMjggODQxLjg5XSAvQ29udGVudHMgNCAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCAwID4+CnN0cmVhbQplbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCA1CjAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMTMgMDAwMDAgbiAKMDAwMDAwMDYxIDAwMDAwIG4gCjAwMDAwMDA5NiAwMDAwMCBuIAowMDAwMDAxNTEgMDAwMDAgbiAKdHJhaWxlcgo8PCAvU2l6ZSA1IC9Sb290IDEgMCBSIC9JbmZvIDYgMCBSID4+CnN0YXJ0eHJlZgo2NQolJUVPRgo=" // base64 di un PDF vuoto
 
     data class ProtocolloRecord(
         val idPratica: String,
         val nomeDocumento: String,
-        val blob: String, // Base64 encoded document
+        val pdfBlob: String, // Base64 encoded PDF
         val dataEmissione: String
     )
 
     private val mockProtocolliDb: Map<String, ProtocolloRecord> = mapOf(
         MOCK_PROTOCOLLO to ProtocolloRecord(
             idPratica = MOCK_PRATICA_ID,
-            nomeDocumento = "documento_mock.docx",
-            blob = MOCK_DB_DOCUMENT_BASE64,
+            nomeDocumento = "documento_mock.pdf",
+            pdfBlob = MOCK_DB_DOCUMENT_BASE64,
             dataEmissione = "05/08/2025"
         )
     )
@@ -48,9 +52,10 @@ class StampaService(private val resourceLoader: ResourceLoader) {
             TipologiaDocumento.SINISTRI -> SinistriTemplater(resourceLoader)
         }
         val documentBytes = templater.processTemplate(pratica, protocollo)
+        val pdfBytes = convertToPdf(documentBytes)
         // TODO: Implementare la funzione che inserisce un record protocollo nel database di AUX
         // quando viene generato un nuovo protocollo (GET /stampa/{idPratica}/{tipologia}).
-        return ByteArrayResource(documentBytes)
+        return ByteArrayResource(pdfBytes)
     }
 
     fun getDocumentWithProtocol(protocollo: String): Pair<Resource, String> {
@@ -59,8 +64,8 @@ class StampaService(private val resourceLoader: ResourceLoader) {
     }
 
     private fun getPraticaFromCordappMock(idPratica: String): Pratica {
-        if (idPratica.length != 9 || !idPratica.matches(Regex("[a-zA-Z0-9]+")))
-            throw PraticaNotFoundException("Formato idPratica non valido.")
+        if (idPratica.length != 8 || !idPratica.matches(Regex("[a-zA-Z0-9]+")))
+            throw PraticaNotFoundException("Formato idPratica non valido. Richiesti 8 caratteri alfanumerici.")
 
         if (!idPratica.equals(MOCK_PRATICA_ID, ignoreCase = true))
             throw PraticaNotFoundException("Pratica con ID '${idPratica.uppercase()}' non trovata.")
@@ -90,7 +95,14 @@ class StampaService(private val resourceLoader: ResourceLoader) {
         val record = mockProtocolliDb[protocollo]
             ?: throw ProtocoloNotFoundException("Protocollo '$protocollo' non trovato nel mock DB.")
 
-        val decodedBytes = Base64.getDecoder().decode(record.blob)
+        val decodedBytes = Base64.getDecoder().decode(record.pdfBlob)
         return Pair(ByteArrayResource(decodedBytes), record.nomeDocumento)
+    }
+
+    private fun convertToPdf(docxBytes: ByteArray): ByteArray {
+        val wordMLPackage = WordprocessingMLPackage.load(ByteArrayInputStream(docxBytes))
+        val out = ByteArrayOutputStream()
+        Docx4J.toPDF(wordMLPackage, out)
+        return out.toByteArray()
     }
 }


### PR DESCRIPTION
## Summary
- convert templated DOCX files to PDF with docx4j and expose via REST
- document and validate printing endpoints using OpenAPI annotations
- add project setup notes and endpoint details in README

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation on your machine (languageVersion=17))*

------
https://chatgpt.com/codex/tasks/task_e_6892562062448330b47becf8fd14ed11