### PR TITLE
Use JODConverter for PDF generation and move to Java 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ecqs-feature-stampa-protocolli
 
-Servizio REST scritto in **Kotlin** con **Spring Boot** per la generazione e il recupero di documenti PDF relativi a pratiche di prestito. I PDF vengono creati a partire da un template Word (`template.docx`) che viene popolato tramite *poi-tl* e convertito in PDF utilizzando **docx4j-export-fo** e **Apache FOP**.
+Servizio REST scritto in **Kotlin** con **Spring Boot** per la generazione e il recupero di documenti PDF relativi a pratiche di prestito. I PDF vengono creati a partire da un template Word (`template.docx`) che viene popolato tramite *poi-tl* e convertito in PDF tramite **JODConverter** e **LibreOffice**.
 
 ## Endpoints principali
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0.0"
 
 java {
         toolchain {
-                languageVersion = JavaLanguageVersion.of(17)
+                languageVersion = JavaLanguageVersion.of(21)
         }
 }
 
@@ -23,8 +23,7 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
         implementation("com.deepoove:poi-tl:1.12.2")
-        implementation("org.docx4j:docx4j-JAXB-ReferenceImpl:11.4.9")
-        implementation("org.docx4j:docx4j-export-fo:11.4.9")
+        implementation("org.jodconverter:jodconverter-local:4.4.6")
         implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")


### PR DESCRIPTION
## Summary
- replace Docx4J conversion with JODConverter + LibreOffice
- upgrade Gradle toolchain to Java 21
- update documentation for the new PDF converter

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies, status code 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_689261c9a4b48330a836a6c845792f77